### PR TITLE
IP 0.0.0.0 breaks loading on windows

### DIFF
--- a/main/main.js
+++ b/main/main.js
@@ -4,7 +4,7 @@ import windowStateKeeper from 'electron-window-state'
 import installExtension, { REACT_DEVELOPER_TOOLS } from 'electron-devtools-installer'
 
 const { DEV, PORT = '8080' } = process.env
-const windowUrl = DEV ? `http://0.0.0.0:${PORT}/` : `file://${app.getAppPath()}/dist/index.html`
+const windowUrl = DEV ? `http://localhost:${PORT}/` : `file://${app.getAppPath()}/dist/index.html`
 
 let mainWindow
 


### PR DESCRIPTION
Hi!

I was looking for an nwb starter for electron and I found yours. Nice job packaging things together so cleanly.

While testing it on my windows setup I found that the 0.0.0.0 ip address on the main.js for development setup wasn't being resolved to localhost as the dev server was setup. This small change made it work as intended on windows.